### PR TITLE
feat: Initial refactor and fixes

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import dynamic from "next/dynamic";
 import GlassContainer from "@/components/GlassContainer";
 import { blogPosts } from "@/data/blogPosts";

--- a/src/components/AboutClient.tsx
+++ b/src/components/AboutClient.tsx
@@ -15,7 +15,7 @@ export default function AboutClient() {
         <GlassContainer>
           <h1 className="text-4xl font-bold mb-8">About Me</h1>
           <div className="prose prose-lg max-w-none">
-            {aboutMe}
+            <p>{aboutMe.bio}</p>
           </div>
         </GlassContainer>
       </div>

--- a/src/components/HeroGenerativeArt.tsx
+++ b/src/components/HeroGenerativeArt.tsx
@@ -2,6 +2,7 @@
 import dynamic from "next/dynamic"
 import { useTheme } from "./ThemeProvider"
 import React from "react"
+import type P5 from "p5"
 
 const Sketch = dynamic(() => import("react-p5").then(mod => mod.default), { ssr: false })
 
@@ -9,14 +10,14 @@ export default function HeroGenerativeArt() {
   const { theme } = useTheme()
 
   // Spiral animation inspired by user p5.js code
-  const setup = (p5: any, canvasParentRef: any) => {
+  const setup = (p5: P5, canvasParentRef: HTMLElement) => {
     p5.createCanvas(p5.windowWidth, 400).parent(canvasParentRef)
     p5.frameRate(30)
     p5.background(theme === "dark" ? 0 : 255)
   }
 
   let f = 0
-  const draw = (p5: any) => {
+  const draw = (p5: P5) => {
     if (theme === "dark") {
       p5.fill(0, 20)
     } else {
@@ -29,8 +30,8 @@ export default function HeroGenerativeArt() {
       p5.push()
       p5.rotate(a)
       for (let i = 1; i > 0; i -= 0.005) {
-        let x = p5.noise(i - f, f / 3, a) * i * p5.width * 0.5
-        let y = p5.noise(f / 2, i, a) * i * p5.width * 0.5
+        const x = p5.noise(i - f, f / 3, a) * i * p5.width * 0.5
+        const y = p5.noise(f / 2, i, a) * i * p5.width * 0.5
         if (theme === "dark") {
           p5.stroke(255, 180 * (1 - i))
         } else {
@@ -43,7 +44,7 @@ export default function HeroGenerativeArt() {
     f += 0.01
   }
 
-  const windowResized = (p5: any) => {
+  const windowResized = (p5: P5) => {
     p5.resizeCanvas(p5.windowWidth, 400)
   }
 

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import GlassContainer from '@/components/GlassContainer'
+import Link from 'next/link'
 
 // Dynamically import animations to avoid SSR issues
 const HeroAnimation = dynamic(() => import('../components/HeroGenerativeArt'), { ssr: false })
@@ -27,18 +28,18 @@ export default function HomeClient() {
               </p>
               
               <div className="flex gap-4 items-center flex-col sm:flex-row">
-                <a
+                <Link
                   className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-accent text-background gap-2 hover:bg-accent-dark font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
                   href="/projects"
                 >
                   View Projects
-                </a>
-                <a
+                </Link>
+                <Link
                   className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto"
                   href="/blog"
                 >
                   Read Blog
-                </a>
+                </Link>
               </div>
             </div>
           </GlassContainer>

--- a/src/components/LoaderAnimation.tsx
+++ b/src/components/LoaderAnimation.tsx
@@ -6,9 +6,10 @@ export default function LoaderAnimation() {
   const sketchRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const p5 = require("p5");
+    // Use the imported p5Types directly as the constructor
     const sketch = (s: p5Types) => {
-      let n = 36, t = 0;
+      const n = 36; // Changed to const
+      let t = 0; // t is reassigned, so it stays let
       s.setup = () => {
         const canvas = s.createCanvas(300, 300);
         if (sketchRef.current) {
@@ -34,8 +35,11 @@ export default function LoaderAnimation() {
         t++;
       };
     };
-    const p5Instance = new p5(sketch);
-    return () => p5Instance.remove();
+
+    const p5Instance = new p5Types(sketch);
+    return () => {
+      p5Instance.remove();
+    };
   }, []);
 
   return (

--- a/src/components/LogoAnimation.tsx
+++ b/src/components/LogoAnimation.tsx
@@ -9,7 +9,7 @@ export default function LogoAnimation() {
   const isBlackOnWhite = theme === "light";
 
   useEffect(() => {
-    const p5 = require("p5");
+    // const p5 = require("p5"); // Removed require
     const sketch = (s: p5Types) => {
       s.setup = () => {
         const canvas = s.createCanvas(400, 400);
@@ -46,7 +46,7 @@ export default function LogoAnimation() {
       };
     };
 
-    const p5Instance = new p5(sketch);
+    const p5Instance = new p5Types(sketch); // Used p5Types as constructor
     return () => p5Instance.remove();
   }, [isBlackOnWhite, toggleTheme]);
 

--- a/src/components/SpiralBackgroundAnimation.tsx
+++ b/src/components/SpiralBackgroundAnimation.tsx
@@ -9,7 +9,7 @@ export default function SpiralBackgroundAnimation() {
   const isDark = theme === "dark";
 
   useEffect(() => {
-    const p5 = require("p5");
+    // const p5 = require("p5"); // Removed require
     const sketch = (s: p5Types) => {
       let f = 0;
       s.setup = () => {
@@ -20,7 +20,11 @@ export default function SpiralBackgroundAnimation() {
         s.frameRate(30);
       };
       s.draw = () => {
-        isDark ? s.fill(0, 20) : s.fill(255, 20);
+        if (isDark) {
+          s.fill(0, 20);
+        } else {
+          s.fill(255, 20);
+        }
         s.noStroke();
         s.rect(0, 0, s.width, s.height);
         s.translate(s.width / 2, s.height / 2);
@@ -30,9 +34,11 @@ export default function SpiralBackgroundAnimation() {
           for (let i = 1; i > 0; i -= 0.005) {
             const x = s.noise(i - f, f / 3, a) * i * s.width;
             const y = s.noise(f / 2, i, a) * i * s.width;
-            isDark
-              ? s.stroke(255, 180 * (1 - i))
-              : s.stroke(0, 180 * i);
+            if (isDark) {
+              s.stroke(255, 180 * (1 - i));
+            } else {
+              s.stroke(0, 180 * i);
+            }
             s.point(x, y);
           }
           s.pop();
@@ -41,7 +47,7 @@ export default function SpiralBackgroundAnimation() {
       };
       s.windowResized = () => s.resizeCanvas(s.windowWidth, s.windowHeight);
     };
-    const p5Instance = new p5(sketch);
+    const p5Instance = new p5Types(sketch); // Used p5Types as constructor
     return () => p5Instance.remove();
   }, [isDark]);
 

--- a/src/sanity/schemaTypes/dataVisualization.ts
+++ b/src/sanity/schemaTypes/dataVisualization.ts
@@ -15,8 +15,7 @@ export default defineType({
       title: 'title',
       chartType: 'chartType',
     },
-    // @ts-ignore
-    prepare(selection) {
+    prepare(selection: { title?: string; chartType?: string }) {
       const { title, chartType } = selection
       return {
         title: title || 'Data Visualization',

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -1,9 +1,9 @@
-// @ts-ignore - Using any for schema types
+import type { SchemaTypeDefinition } from 'sanity'
 import post from './post'
 import project from './project'
 import siteSettings from './siteSettings'
 import dataVisualization from './dataVisualization'
 
-export const schema: { types: any[] } = {
+export const schema: { types: SchemaTypeDefinition[] } = {
   types: [post, project, siteSettings, dataVisualization],
 }

--- a/src/sanity/schemaTypes/post.ts
+++ b/src/sanity/schemaTypes/post.ts
@@ -1,16 +1,13 @@
-import { defineField, defineType } from 'sanity'
+import { defineField, defineType, type Rule } from 'sanity'
 
 export default defineType({
   name: 'post',
   title: 'Post',
   type: 'document',
   fields: [
-    // @ts-ignore
-    defineField({ name: 'title', title: 'Title', type: 'string', validation: Rule => Rule.required() }),
-    // @ts-ignore
-    defineField({ name: 'slug', title: 'Slug', type: 'slug', options: { source: 'title', maxLength: 96 }, validation: Rule => Rule.required() }),
-    // @ts-ignore
-    defineField({ name: 'publishedAt', title: 'Published at', type: 'datetime', validation: Rule => Rule.required() }),
+    defineField({ name: 'title', title: 'Title', type: 'string', validation: (Rule: Rule) => Rule.required() }),
+    defineField({ name: 'slug', title: 'Slug', type: 'slug', options: { source: 'title', maxLength: 96 }, validation: (Rule: Rule) => Rule.required() }),
+    defineField({ name: 'publishedAt', title: 'Published at', type: 'datetime', validation: (Rule: Rule) => Rule.required() }),
     defineField({ name: 'excerpt', title: 'Excerpt', type: 'text' }),
     defineField({ name: 'mainImage', title: 'Main image', type: 'image', options: { hotspot: true } }),
     defineField({ name: 'body', title: 'Body', type: 'array', of: [{ type: 'block' }, { type: 'image' }, { type: 'dataVisualization' }] }),

--- a/src/sanity/schemaTypes/project.ts
+++ b/src/sanity/schemaTypes/project.ts
@@ -1,16 +1,13 @@
-import { defineField, defineType } from 'sanity'
+import { defineField, defineType, type Rule } from 'sanity'
 
 export default defineType({
   name: 'project',
   title: 'Project',
   type: 'document',
   fields: [
-    // @ts-ignore
-    defineField({ name: 'title', title: 'Title', type: 'string', validation: Rule => Rule.required() }),
-    // @ts-ignore
-    defineField({ name: 'slug', title: 'Slug', type: 'slug', options: { source: 'title', maxLength: 96 }, validation: Rule => Rule.required() }),
-    // @ts-ignore
-    defineField({ name: 'date', title: 'Date', type: 'datetime', validation: Rule => Rule.required() }),
+    defineField({ name: 'title', title: 'Title', type: 'string', validation: (Rule: Rule) => Rule.required() }),
+    defineField({ name: 'slug', title: 'Slug', type: 'slug', options: { source: 'title', maxLength: 96 }, validation: (Rule: Rule) => Rule.required() }),
+    defineField({ name: 'date', title: 'Date', type: 'datetime', validation: (Rule: Rule) => Rule.required() }),
     defineField({ name: 'excerpt', title: 'Excerpt', type: 'text' }),
     defineField({ name: 'mainImage', title: 'Main image', type: 'image', options: { hotspot: true } }),
     defineField({ name: 'detailedDescription', title: 'Detailed Description', type: 'array', of: [{ type: 'block' }, { type: 'image' }, { type: 'dataVisualization' }] }),

--- a/src/sanity/schemaTypes/siteSettings.ts
+++ b/src/sanity/schemaTypes/siteSettings.ts
@@ -1,12 +1,11 @@
-import { defineField, defineType } from 'sanity'
+import { defineField, defineType, type Rule } from 'sanity'
 
 export default defineType({
   name: 'siteSettings',
   title: 'Site Settings',
   type: 'document',
   fields: [
-    // @ts-ignore
-    defineField({ name: 'title', title: 'Site Title', type: 'string', validation: Rule => Rule.required() }),
+    defineField({ name: 'title', title: 'Site Title', type: 'string', validation: (Rule: Rule) => Rule.required() }),
     defineField({ name: 'description', title: 'Description', type: 'text' }),
     defineField({
       name: 'socialLinks',

--- a/src/sanity/schemas/index.ts
+++ b/src/sanity/schemas/index.ts
@@ -1,5 +1,5 @@
-import post from './post'
-import project from './project'
-import siteSettings from './siteSettings'
+import post from '../schemaTypes/post'
+import project from '../schemaTypes/project'
+import siteSettings from '../schemaTypes/siteSettings'
 
 export const schemaTypes = [post, project, siteSettings] 

--- a/src/sanity/structure.ts
+++ b/src/sanity/structure.ts
@@ -1,7 +1,6 @@
-import { StructureResolver } from 'sanity/desk'
+import { type StructureResolver, type StructureBuilder } from 'sanity/desk'
 
-// @ts-ignore - Using any type for Sanity structure
-export const structure: StructureResolver = (S) =>
+export const structure: StructureResolver = (S: StructureBuilder) =>
   S.list()
     .title('Content')
     .items([

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,9 +16,10 @@ const config: Config = {
           DEFAULT: '#fafafa', // main text
           subtle: '#a1a1aa', // subtle text
         },
+        honey: '#FFB000', // Define honey color
         // Signature accent color (e.g., blue-violet)
         accent: {
-          DEFAULT: '#7c3aed', // signature accent
+          DEFAULT: 'var(--color-honey)', // Reference honey color
           light: '#a78bfa',
           dark: '#4c1d95',
         },


### PR DESCRIPTION
This commit includes the initial batch of fixes and refactorings based on the issue description.

Completed Steps:
- Environment Bootstrap: Cleaned project, installed dependencies (npm ci), and verified Node.js version.
- Initial Build Error Fix: Resolved `ssr: false` issue in `src/app/blog/[slug]/page.tsx` by adding "use client".
- Initial Tailwind CSS Error Fix: Addressed `theme(colors.accent.DEFAULT)` by defining `accent.DEFAULT` in `tailwind.config.ts`.
- TypeScript Error Resolution (Partial):
    - Corrected import paths in `src/sanity/schemas/index.ts`.
    - Fixed prop typing in `src/components/AboutClient.tsx`.
- Linting Error Resolution: Fixed all ESLint errors across the codebase, including type annotations, const usage, Next.js Link components, and p5.js imports.

Persistent Issues & Blockers:
The following issues prevented further progress:

1.  `next build` Error (Dynamic Page Params): A critical type error occurs during `npx next build` for dynamic pages (e.g., `src/app/blog/[slug]/page.tsx`). The build process incorrectly expects the `params` prop to be a `Promise<any>` instead of the documented `{ slug: string }`. This seems to be an issue with Next.js v15.3.3's build process or type validation. Attempts to fix this by aligning with documentation or explicitly typing with `NextPage` were unsuccessful.

2.  Tailwind CSS Error (Reappeared): The `theme(colors.accent.DEFAULT)` error, though initially fixed, reappeared in subsequent builds, particularly after clearing the `.next` cache. This suggests potential caching or build state issues with Tailwind token resolution.

3.  TypeScript Error - `StudioClient.tsx`: A persistent error: `Type '{ config: any; }' is not assignable to type 'IntrinsicAttributes & NextStudioProps'. Property 'config' does not exist...` This contradicts `next-sanity` (v9.12.0) documentation. Casting to `any` or other typing attempts did not resolve it.

4.  TypeScript Errors - Sanity Schema Types: Errors like `Cannot use namespace 'SchemaTypeDefinition' as a type` when using `import type { SchemaTypeDefinition } from 'sanity'` for Sanity schema files. This points to issues with type resolution for the Sanity library.

Due to these blocking issues, particularly the `next build` failure, later planned work (filesystem consistency, full routing fix, component integrity, style audit, data-model alignment, accessibility, and documentation) could not be completed.